### PR TITLE
Fix Role-Based Root Paths and Remove Auto-Logout on Sign-In

### DIFF
--- a/source/app/controllers/application_controller.rb
+++ b/source/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  before_action :clear_stale_sessions
   before_action :sign_out_on_public_pages
   before_action :set_selected_course, unless: :skip_set_selected_course?
 
@@ -19,16 +18,6 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def clear_stale_sessions
-    return if @sessions_cleared
-    
-    if user_signed_in?
-      sign_out current_user
-      redirect_to root_path, alert: 'Previous session was cleared. Please sign in again.'
-    end
-    
-    @sessions_cleared = true
-  end
 
   # Force sign-out on certain public pages
   def sign_out_on_public_pages

--- a/source/config/routes.rb
+++ b/source/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
+  authenticated :user, ->(u) { u.instructor? } do
+    root to: 'course_selection#index', as: :instructor_root
+  end
+
+  authenticated :user, ->(u) { u.student? } do
+    root to: 'course_selection#index', as: :student_root
+  end
 
   unauthenticated do
     root 'pages#home'


### PR DESCRIPTION
### Pull Request Description
This PR addresses an issue that was introduced in the most recent commit where users were automatically logged out upon attempting to sign in. Changes include:

- Setting role-based root paths in `routes.rb` for `instructor` and `student` users to direct them to `course_selection#index` based on their role.
- Removing the `clear_stale_sessions` method in `ApplicationController`, which was previously causing users to be signed out immediately after login.
