### PR TITLE
[#130] Add static analysis job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,39 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
       - develop
   pull_request:
     branches:
-      - main
+      - master
       - develop
   workflow_dispatch: # Allows manual triggering
 
 jobs:
+  static_analysis:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: source
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.5
+
+      - name: Install Ruby dependencies
+        run: |
+          gem install bundler
+          bundle update
+          bundle install --jobs 4 --retry 3
+
+      - name: Run Rubocop
+        run: bundle exec rubocop
+
   test:
     runs-on: ubuntu-latest
     defaults:
@@ -72,7 +96,7 @@ jobs:
           bundle exec rspec .
 
   deploy:
-    needs: test
+    needs: [test, static_analysis]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     defaults:
@@ -105,4 +129,3 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
           heroku run rails db:seed --app ${{ secrets.HEROKU_APP_NAME }}
-        

--- a/source/Gemfile
+++ b/source/Gemfile
@@ -5,6 +5,9 @@ ruby '3.3.5'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 7.1.4'
 
+# Use PostgreSQL as the database
+gem "pg", "~> 1.2"
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 
@@ -46,11 +49,6 @@ gem 'ostruct'
 
 # Bootstrap for styling
 gem 'bootstrap', '~> 5.3.3'
-
-group :production do
-  # Use PostgreSQL as the database
-  gem "pg", "~> 1.2"
-end
 
 group :development, :test do
   gem 'faker'


### PR DESCRIPTION
* Added a `static_analysis` job to the CI workflow for our GitHub Actions
* This job runs Rubocop (a Ruby formatter) in all of our repository, on PRs based on master, and blocks merging if the static code analysis fails.