### PR TITLE
[#136] Fix Test CI Job

### DIFF
--- a/source/spec/rails_helper.rb
+++ b/source/spec/rails_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false


### PR DESCRIPTION
- Rails uses transactional fixtures by default in tests, which wraps each test in a transaction to ensure data is rolled back at the end of the test. This can conflict with SQLite’s handling of transactions, resulting in a deadlock and rspec being frozen indefinitely. To fix this, I simply disabled transactional fixtures.